### PR TITLE
Update Bullet.js

### DIFF
--- a/src/js/editing/Bullet.js
+++ b/src/js/editing/Bullet.js
@@ -263,7 +263,7 @@ export default class Bullet {
    */
   findList(node) {
     return node
-      ? lists.find(node.children, child => ['OL', 'UL'].indexOf(child.nodeName) > -1)
+      ? node.children && lists.find(node.children, child => ['OL', 'UL'].indexOf(child.nodeName) > -1)
       : null;
   }
 


### PR DESCRIPTION
Prevent error when node.children is undefined.
This can happen when line breaks (text nodes) are within the bulletpoint-tree.

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- When the HTML code is pretty-printed, the indentation of bullet points is not working anymore
How to reproduce:
- Switch to HTML view
- insert pretty-printed bullet-list:
```
  <ul>
   <li>a</li>
   <li>b</li>
  </ul>
```
- switch back to WYSIWYG
- try to do indentation 
- The browser console will show an error: "Uncaught TypeError: Cannot read properties of undefined (reading 'length')"

#### Where should the reviewer start?

- start on the src/js/editing/Bullet.js

#### How should this be manually tested?

- switch to HTML-code view
- insert a HTML snippet like mentioned below
- switch to WYSIWYG and try whether indentation works

#### Any background context you want to provide?

- After saving HTML, we use JSOUP to filter attributes and tags to prevent script injection
- This also creates lines breaks which are not correctly handled by summernote

#### What are the relevant tickets?
fixes issue 4515 of summernote.js

#### Screenshot (if for frontend)
![image](https://github.com/HoffmannTom/summernote/assets/27145868/06af9b52-71e1-49f1-9c45-2fdc2a874e3c)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
